### PR TITLE
Using default-theme background color on selected file

### DIFF
--- a/styles/tree-view-git-modified.less
+++ b/styles/tree-view-git-modified.less
@@ -5,9 +5,6 @@
 @import "ui-variables";
 
 .tree-view-git-modified {
-  .selected:before {
-    background-color: white !important;
-  }
   .status-new {
     color: green !important;
   }


### PR DESCRIPTION
Many Atom users using dark theme, so white is so bright and disturbing. Why just don't use default theme color? ;)