### PR TITLE
Avoid duplicate entries

### DIFF
--- a/lib/tree-view-git-modified-pane-view.coffee
+++ b/lib/tree-view-git-modified-pane-view.coffee
@@ -91,7 +91,10 @@ class TreeViewOpenFilesPaneView
   #       console.log err
 
   reloadStatuses: (self, repo) ->
-    if repo?
+    if self.isReloading
+      console.warn 'Already performing reloadStatuses -- skipping this one!'
+    else if repo?
+      self.isReloading = true
       self.removeAll()
       repoPath = repo.repo.workingDirectory
       for filePath of repo.statuses
@@ -99,6 +102,7 @@ class TreeViewOpenFilesPaneView
           self.addItem filePath, repoPath, 'status-modified'
         if repo.isPathNew(filePath)
           self.addItem filePath, repoPath, 'status-new'
+      self.isReloading = false
 
   setPane: (pane) ->
     @paneSub.add pane.observeActiveItem (item) =>


### PR DESCRIPTION
Relates to #1.

Sometimes, the test `repo.isPathModified` triggers another invocation of
`reloadStatuses`. Therefore, the simplest fix would be to skip those
additional `reloadStatuses` while already reloading.