### PR TITLE
fixed some bugs

### DIFF
--- a/lib/tree-view-git-modified-pane-view.coffee
+++ b/lib/tree-view-git-modified-pane-view.coffee
@@ -15,25 +15,23 @@ class TreeViewOpenFilesPaneView
     repoPath = repo.repo.workingDirectory
     repoName = repoPath.split('/')[repoPath.split('/').length-1]
 
-    @element = document.createElement('ul')
-    @element.classList.add('tree-view', 'list-tree', 'has-collapsable-children', 'focusable-panel')
-    nested = document.createElement('li')
-    nested.classList.add('list-nested-item', 'expanded')
-    @container = document.createElement('ul')
-    @container.classList.add('list-tree')
-    header = document.createElement('div')
-    header.classList.add('list-item')
+    @element = document.createElement('li')
+    @element.setAttribute('is', 'tree-view-git-modified')
+    @element.classList.add('tree-view-git-modified', 'list-nested-item', 'expanded')
+    @container = document.createElement('ol')
+    @container.classList.add('entries', 'list-tree')
+    @header = document.createElement('div')
+    @header.classList.add('header', 'list-item')
 
     headerSpan = document.createElement('span')
     headerSpan.classList.add('name', 'icon', 'icon-mark-github')
     headerSpan.setAttribute('data-name', 'Git Modified: ' + repoName)
     headerSpan.innerText = 'Git Modified: ' + repoName
-    header.appendChild headerSpan
-    nested.appendChild header
-    nested.appendChild @container
-    @element.appendChild nested
+    @header.appendChild headerSpan
+    @element.appendChild @header
+    @element.appendChild @container
 
-    $(@element).on 'click', '.list-nested-item > .list-item', ->
+    $(@header).on 'click', ->
       nested = $(this).closest('.list-nested-item')
       nested.toggleClass('expanded')
       nested.toggleClass('collapsed')
@@ -194,6 +192,12 @@ class TreeViewOpenFilesPaneView
 
   # Returns an object that can be retrieved when package is activated
   serialize: ->
+
+  hide: ->
+    @element.classList.add 'hidden'
+
+  show: ->
+    @element.classList.remove 'hidden'
 
   # Tear down any state and detach
   destroy: ->

--- a/lib/tree-view-git-modified-view.coffee
+++ b/lib/tree-view-git-modified-view.coffee
@@ -9,9 +9,7 @@ class TreeViewGitModifiedView
   constructor: (serializedState) ->
 
     # Create root element
-    @element = document.createElement('div')
-
-    @element.classList.add('tree-view-git-modified')
+    @element = document.createElement('li')
 
     @treeViewGitModifiedPaneViewArray = []
 
@@ -20,7 +18,7 @@ class TreeViewGitModifiedView
     @loadRepos()
 
     @paneSub.add atom.project.onDidChangePaths (path) =>
-        @loadRepos()
+      @loadRepos()
 
     # @paneSub.add atom.workspace.observePanes (pane) =>
     #   @treeViewGitModifiedPaneView.setPane pane
@@ -35,11 +33,18 @@ class TreeViewGitModifiedView
 
     # Remove all existing panels
     for tree in @treeViewGitModifiedPaneViewArray
-        tree.destroy()
+      tree.hide()
 
     Promise.all(atom.project.getDirectories().map(
       atom.project.repositoryForDirectory.bind(atom.project))).then (repos) ->
         for repo in repos
+          if repo.repo == null
+            for tree in self.treeViewGitModifiedPaneViewArray
+              if repo.path == tree.repo.path
+                tree.show()
+              console.log(tree)
+          else
+            console.log(repo)
             treeViewGitModifiedPaneView = new TreeViewGitModifiedPaneView repo
             treeViewGitModifiedPaneView.setRepo repo
             self.treeViewGitModifiedPaneViewArray.push treeViewGitModifiedPaneView
@@ -73,4 +78,5 @@ class TreeViewGitModifiedView
   show: ->
     requirePackages('tree-view').then ([treeView]) =>
       treeView.treeView.find('.tree-view-scroller').css 'background', treeView.treeView.find('.tree-view').css 'background'
-      treeView.treeView.prepend @element
+      parentElement = treeView.treeView.element.querySelector('.tree-view-scroller .tree-view')
+      parentElement.insertBefore(@element, parentElement.firstChild)


### PR DESCRIPTION
fixes issue https://github.com/rjaviervega/tree-view-git-modified/issues/3 by inserting only the li element straight into the (.tree-view-scroller .list-tree) element instead of as a sibling to it the (.tree-view-scroller) element with its own div wrapper

also fixes the issue where when we navigate away from a project with Project Viewer (great package) and then back again atom.project.repositoryForDirectory.bind(atom.project) will return null for the repo.repo and you cant create another paneSub. To avoid this instead of destroying the pane subs when we navigate away, we just hide them and if we navigate back again we show them again.